### PR TITLE
Enable forward compatibility with new response fields

### DIFF
--- a/src/HTTPClient.php
+++ b/src/HTTPClient.php
@@ -102,8 +102,7 @@ class HTTPClient extends VAXClient
         $obj = new $reply_class();
         try {
             if (method_exists($obj, 'mergeFromJsonString')) {
-                $ignore_unknown = $options['ignore_unknown'] ?? false;
-                $obj->mergeFromJsonString((string)$response->getBody(), $ignore_unknown);
+                $obj->mergeFromJsonString((string)$response->getBody(), true);
             } else {
                 throw new SDKException("Could not parse obj.");
             }

--- a/src/HTTPClient.php
+++ b/src/HTTPClient.php
@@ -102,7 +102,8 @@ class HTTPClient extends VAXClient
         $obj = new $reply_class();
         try {
             if (method_exists($obj, 'mergeFromJsonString')) {
-                $obj->mergeFromJsonString((string) $response->getBody());
+                $ignore_unknown = $options['ignore_unknown'] ?? false;
+                $obj->mergeFromJsonString((string)$response->getBody(), $ignore_unknown);
             } else {
                 throw new SDKException("Could not parse obj.");
             }


### PR DESCRIPTION
Keeping the SDK update to date for all sub libraries can be difficult, especially since the Vendasta SDK is used across organizations.

This PR gives the option to ignore new fields from responses, so that API response with new fields don't break older clients.
